### PR TITLE
update wf id quick pick items + edit and search buttons

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,3 +61,53 @@ export async function getWorkspaceFolder() {
 	}
 	return await vscode.window.showWorkspaceFolderPick();
 }
+
+export interface QuickPickOptions {
+    title?: string;
+    items?: vscode.QuickPickItem[];
+    buttons?: vscode.QuickInputButton[];
+    canSelectMany?: boolean;
+    placeHolder?: string;
+}
+
+export type QuickPickResult = vscode.QuickPickItem | vscode.QuickInputButton;
+
+export function isQuickPickItem(item?: QuickPickResult): item is vscode.QuickPickItem {
+    return item !== undefined && "label" in item;
+}
+
+export async function showQuickPick(options: QuickPickOptions) {
+    const disposables: { dispose(): any }[] = [];
+    try {
+        return await new Promise<QuickPickResult | undefined>((resolve, reject) => {
+            const input = vscode.window.createQuickPick();
+            input.title = options.title;
+            input.placeholder = options.placeHolder;
+            input.canSelectMany = options.canSelectMany ?? false;
+            input.items = options.items ?? [];
+            input.buttons = options.buttons ?? [];
+
+            disposables.push(
+                input.onDidTriggerButton(async (button) => {
+                    resolve(button);
+                    input.hide();
+                }),
+                input.onDidChangeSelection(items => {
+                    const item = items[0];
+                    if (item) {
+                        resolve(item);
+                        input.hide();
+                    }
+                }),
+                input.onDidHide(() => {
+                    resolve(undefined);
+                    input.dispose();
+                }),
+            );
+
+            input.show();
+        });
+    } finally {
+        disposables.forEach(d => d.dispose());
+    }
+}


### PR DESCRIPTION
This PR makes two changes to improve the TT Dbg code lens experience:

* show WF status created at, auth user, status and WF ID in the workflow quick pick
* Add `edit` and `search` buttons to WF quick pick. 
  * `edit` allows user to specify a WF ID via input box. Note, this value is validated before launching debugger
  * `search` open extenal browser to user dashboard

NOTE: dashboard launch not implemented yet