### PR TITLE
add dbos-ttdbg.debug_pre_launch_task config setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,18 +44,21 @@
     "configuration": {
       "title": "DBOS Time Travel Debugger",
       "properties": {
+        "dbos-ttdbg.debug_pre_launch_task": {
+          "type": "string"
+        },
         "dbos-ttdbg.debug_proxy_port": {
           "type": "number",
           "default": 2345
+        },
+        "dbos-ttdbg.prov_db_database": {
+          "type": "string"
         },
         "dbos-ttdbg.prov_db_host": {
           "type": "string"
         },
         "dbos-ttdbg.prov_db_port": {
           "type": "number"
-        },
-        "dbos-ttdbg.prov_db_database": {
-          "type": "string"
         },
         "dbos-ttdbg.prov_db_user": {
           "type": "string"

--- a/src/ProvenanceDatabase.ts
+++ b/src/ProvenanceDatabase.ts
@@ -19,6 +19,8 @@ export interface workflow_status {
     updated_at: string;
 }
 
+export type DbosMethodInfo = { name: string; type: DbosMethodType };
+
 export class ProvenanceDatabase {
     private _databases: Map<number, Client> = new Map();
 
@@ -50,7 +52,7 @@ export class ProvenanceDatabase {
         return db;
     }
 
-    async getWorkflowStatuses(clientConfig: CloudConfig, method?: { name: string; type: DbosMethodType }): Promise<workflow_status[]> {
+    async getWorkflowStatuses(clientConfig: CloudConfig, method?: DbosMethodInfo): Promise<workflow_status[]> {
         const db = await this.connect(clientConfig);
         const results = method
             ? await db.query<workflow_status>('SELECT * FROM dbos.workflow_status WHERE name = $1 ORDER BY created_at DESC LIMIT 10', [getDbosWorkflowName(method.name, method.type)])

--- a/src/ProvenanceDatabase.ts
+++ b/src/ProvenanceDatabase.ts
@@ -1,4 +1,4 @@
-import { Client, ClientConfig } from 'pg';
+import { Client } from 'pg';
 import { logger } from './extension';
 import { DbosMethodType, getDbosWorkflowName } from './sourceParser';
 import { hashClientConfig } from './utils';
@@ -50,17 +50,18 @@ export class ProvenanceDatabase {
         return db;
     }
 
-    async getWorkflowStatuses(clientConfig: CloudConfig, name: string, $type: DbosMethodType): Promise<workflow_status[]> {
-        const wfName = getDbosWorkflowName(name, $type);
+    async getWorkflowStatuses(clientConfig: CloudConfig, method?: { name: string; type: DbosMethodType }): Promise<workflow_status[]> {
         const db = await this.connect(clientConfig);
-        const results = await db.query<workflow_status>('SELECT * FROM dbos.workflow_status WHERE name = $1 ORDER BY created_at DESC LIMIT 10', [wfName]);
+        const results = method
+            ? await db.query<workflow_status>('SELECT * FROM dbos.workflow_status WHERE name = $1 ORDER BY created_at DESC LIMIT 10', [getDbosWorkflowName(method.name, method.type)])
+            : await db.query<workflow_status>('SELECT * FROM dbos.workflow_status ORDER BY created_at DESC LIMIT 10');
         return results.rows;
     }
 
-    async getWorkflowStatus(clientConfig: CloudConfig, wfid: string): Promise<workflow_status | undefined> {
+    async getWorkflowStatus(clientConfig: CloudConfig, workflowID: string): Promise<workflow_status | undefined> {
         const db = await this.connect(clientConfig);
-        const results = await db.query<workflow_status>('SELECT * FROM dbos.workflow_status WHERE workflow_uuid = $1', [wfid]);
-        if (results.rows.length > 1) { throw new Error(`Multiple workflow status records found for workflow ID ${wfid}`); }
+        const results = await db.query<workflow_status>('SELECT * FROM dbos.workflow_status WHERE workflow_uuid = $1', [workflowID]);
+        if (results.rows.length > 1) { throw new Error(`Multiple workflow status records found for workflow ID ${workflowID}`); }
         return results.rows.length === 1 ? results.rows[0] : undefined;
     }
 }

--- a/src/codeLensProvider.ts
+++ b/src/codeLensProvider.ts
@@ -3,6 +3,7 @@ import ts from 'typescript';
 import { startDebuggingCodeLensCommandName } from './commands';
 import { logger } from './extension';
 import { getDbosMethodType, parse } from './sourceParser';
+import { DbosMethodInfo } from './ProvenanceDatabase';
 
 export class TTDbgCodeLensProvider implements vscode.CodeLensProvider {
     provideCodeLenses(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
@@ -33,7 +34,7 @@ export class TTDbgCodeLensProvider implements vscode.CodeLensProvider {
                         title: '⏳ Time Travel Debug',
                         tooltip: `Debug ${methodInfo.name} with the DBOS Time Travel Debugger`,
                         command: startDebuggingCodeLensCommandName,
-                        arguments: [folder, methodInfo.name, methodType]
+                        arguments: [folder, { name: methodInfo.name, type: methodType }]
                     });
                 })
                 .filter(<T>(x?: T): x is T => !!x);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,12 +4,97 @@ import { DbosMethodType } from "./sourceParser";
 import { exists, getWorkspaceFolder, isQuickPickItem, showQuickPick } from './utils';
 import { dbos_cloud_dashboard_launch, dbos_cloud_dashboard_url, dbos_cloud_login } from './cloudCli';
 import { CloudConfig } from './configuration';
+import { DbosMethodInfo, workflow_status } from './ProvenanceDatabase';
+
+interface LaunchConfig {
+    // actual launch configs have more fields, but this extension only uses rootPath
+    rootPath: string;
+}
 
 export const cloudLoginCommandName = "dbos-ttdbg.cloud-login";
-export const startDebuggingCodeLensCommandName = "dbos-ttdbg.start-debugging-code-lens";
-export const startDebuggingUriCommandName = "dbos-ttdbg.start-debugging-uri";
+export async function cloudLogin() {
+    try {
+        const folders = vscode.workspace.workspaceFolders ?? [];
+        if (folders.length === 1) {
+            await dbos_cloud_login(folders[0]);
+        } else {
+            throw new Error("This command only works when exactly one workspace folder is open");
+        }
+    } catch (e) {
+        logger.error("cloudLogin", e);
+    }
+}
+
 export const shutdownDebugProxyCommandName = "dbos-ttdbg.shutdown-debug-proxy";
-export const deleteProvDbPasswordsCommandName = "dbos-ttdbg.delete-prov-db-passwords";
+export function shutdownDebugProxy() {
+    try {
+        debugProxy.shutdown();
+    } catch (e) {
+        logger.error("shutdownDebugProxy", e);
+    }
+}
+
+export const deleteProvenanceDatabasePasswordsCommandName = "dbos-ttdbg.delete-prov-db-passwords";
+export async function deleteProvenanceDatabasePasswords() {
+    try {
+        await config.deletePasswords();
+    } catch (e) {
+        logger.error("deleteProvenanceDatabasePasswords", e);
+    }
+}
+
+export const getProxyUrlCommandName = "dbos-ttdbg.get-proxy-url";
+export async function getProxyUrl(cfg?: LaunchConfig) {
+    try {
+        const folder = await getWorkspaceFolder(cfg?.rootPath);
+        if (!folder) {
+            throw new Error("Invalid workspace folder");
+        }
+
+        const port = config.getProxyPort(folder);
+        return `http://localhost:${port}`;
+    } catch (e) {
+        logger.error("getProxyUrl", e);
+        throw e;
+    }
+}
+
+export const pickWorkflowIdCommandName = "dbos-ttdbg.pick-workflow-id";
+export async function pickWorkflowId(cfg?: LaunchConfig) {
+    const folder = await getWorkspaceFolder(cfg?.rootPath);
+    if (!folder) { 
+        return; 
+    }
+
+    const cloudConfig = await config.getCloudConfig(folder);
+    if (cloudConfig) {
+        await debugProxy.launch(cloudConfig);
+    }
+
+    return await showWorkflowPick(folder, { cloudConfig });
+}
+
+export const startDebuggingUriCommandName = "dbos-ttdbg.start-debugging-uri";
+export async function startDebuggingFromUri(wfid: string) {
+    try {
+        const folder = await getWorkspaceFolder();
+        if (!folder) { return; }
+
+        logger.info(`startDebuggingFromUri`, { folder: folder.uri.fsPath, wfid });
+        await startDebugging(folder, async () => { return wfid; });
+    } catch (e) {
+        logger.error("startDebuggingFromUri", e);
+        throw e;
+    }
+}
+
+export const startDebuggingCodeLensCommandName = "dbos-ttdbg.start-debugging-code-lens";
+export async function startDebuggingFromCodeLens(folder: vscode.WorkspaceFolder, method: DbosMethodInfo) {
+    logger.info(`startDebuggingFromCodeLens`, { folder: folder.uri.fsPath, method });
+    await startDebugging(folder, async (cloudConfig) => {
+        return await showWorkflowPick(folder, { cloudConfig, method });
+    });
+}
 
 async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cloudConfig: CloudConfig) => Promise<string | undefined>) {
     try {
@@ -20,15 +105,15 @@ async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cl
             },
             async () => {
                 const cloudConfig = await config.getCloudConfig(folder);
-                if (!cloudConfig) { 
+                if (!cloudConfig) {
                     logger.warn("startDebugging: config.getProvDBConfig returned undefined");
-                    return; 
+                    return;
                 }
-               
+
                 const workflowID = await getWorkflowID(cloudConfig);
-                if (!workflowID) { 
+                if (!workflowID) {
                     logger.warn("startDebugging: getWorkflowID returned undefined");
-                    return; 
+                    return;
                 }
 
                 const workflowStatus = await provDB.getWorkflowStatus(cloudConfig, workflowID);
@@ -38,21 +123,22 @@ async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cl
                 }
 
                 const proxyLaunched = await debugProxy.launch(cloudConfig);
-                if (!proxyLaunched) { 
+                if (!proxyLaunched) {
                     logger.warn("startDebugging: debugProxy.launch returned false");
-                    return; 
+                    return;
                 }
-                
-                const proxyURL = `http://localhost:${config.proxyPort ?? 2345}`;
-                const preLaunchTask = config.preLaunchTask;
+
+                const proxyPort = config.getProxyPort(folder);
+                const preLaunchTask = config.getPreLaunchTask(folder);
                 logger.info(`startDebugging`, { folder: folder.uri.fsPath, database: cloudConfig.database, preLaunchTask, workflowID });
+
                 const debuggerStarted = await vscode.debug.startDebugging(
                     folder,
                     {
                         name: `Time-Travel Debug ${workflowID}`,
                         type: 'node-terminal',
                         request: 'launch',
-                        command: `npx dbos-sdk debug -x ${proxyURL} -u ${workflowID}`,
+                        command: `npx dbos-sdk debug -x http://localhost:${proxyPort} -u ${workflowID}`,
                         preLaunchTask,
                     }
                 );
@@ -68,88 +154,79 @@ async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cl
     }
 }
 
-export async function startDebuggingFromCodeLens(folder: vscode.WorkspaceFolder, methodName: string, $type: DbosMethodType) {
-    logger.info(`startDebuggingFromCodeLens`, { folder: folder.uri.fsPath, name: methodName, type: $type });
-    await startDebugging(folder, async (cloudConfig) => {
-        const statuses = await provDB.getWorkflowStatuses(cloudConfig, methodName, $type);
-        const items = statuses.map(s => <vscode.QuickPickItem>{
-            label: new Date(parseInt(s.created_at)).toLocaleString(),
-            description: `${s.status}${s.authenticated_user.length !== 0 ? ` (${s.authenticated_user})` : ""}`,
-            detail: s.workflow_uuid,
-        });
 
-        const editButton: vscode.QuickInputButton = {
-            iconPath: new vscode.ThemeIcon("edit"),
-            tooltip: "Specify workflow id directly"
-        };
 
-        const dashboardButton: vscode.QuickInputButton = {
-            iconPath: new vscode.ThemeIcon("server"),
-            tooltip: "Select workflow via DBOS User Dashboard"
-        };
 
-        const pickResult = await showQuickPick({
-            buttons : [editButton, dashboardButton],
-            items,
-            canSelectMany: false,
-            title: "Select a workflow ID to debug"
-        });
-        if (pickResult === undefined) { return undefined; }
-        if (isQuickPickItem(pickResult)) {
-            return pickResult.detail;
-        }
-        if (pickResult === editButton) {
-            return await vscode.window.showInputBox({ prompt: "Enter the workflow ID" });
-        } else if (pickResult === dashboardButton) {
-            startOpenDashboardFlow(folder, cloudConfig.appName, methodName, $type)
-                .catch(e => logger.error("startOpenDashboard", e));
-            return undefined;
-        } else {
-            throw new Error(`Unexpected button: ${pickResult.tooltip ?? "<unknown>"}`);
-        }
+async function showWorkflowPick(
+    folder: vscode.WorkspaceFolder,
+    options?: {
+        method?: DbosMethodInfo,
+        cloudConfig?: CloudConfig,
+        showDashboardButton?: boolean,
+    }
+): Promise<string | undefined> {
+    const cloudConfig = options?.cloudConfig ?? await config.getCloudConfig(folder);
+    if (!cloudConfig) {
+        logger.warn("pickWorkflow: config.getCloudConfig returned undefined");
+        return undefined;
+    }
+
+    const statuses = await provDB.getWorkflowStatuses(cloudConfig, options?.method);
+    const items = statuses.map(status => <vscode.QuickPickItem>{
+        label: new Date(parseInt(status.created_at)).toLocaleString(),
+        description: `${status.status}${status.authenticated_user.length !== 0 ? ` (${status.authenticated_user})` : ""}`,
+        detail: status.workflow_uuid,
     });
-}
 
-export async function startDebuggingFromUri(wfid: string) {
-    const folder = await getWorkspaceFolder();
-    if (!folder) { return; }
+    const editButton: vscode.QuickInputButton = {
+        iconPath: new vscode.ThemeIcon("edit"),
+        tooltip: "Specify workflow id directly"
+    };
 
-    logger.info(`startDebuggingFromUri`, { folder: folder.uri.fsPath, wfid });
-    await startDebugging(folder, async () => { return wfid; });
-}
+    const dashboardButton: vscode.QuickInputButton = {
+        iconPath: new vscode.ThemeIcon("server"),
+        tooltip: "Select workflow via DBOS User Dashboard"
+    };
 
-export function shutdownDebugProxy() {
-    try {
-        debugProxy.shutdown();
-    } catch (e) {
-        logger.error("shutdownDebugProxy", e);
+    const pickResult = await showQuickPick({
+        buttons: options?.showDashboardButton ?? false ? [editButton, dashboardButton] : [editButton],
+        items,
+        canSelectMany: false,
+        title: "Select a workflow ID to debug"
+    });
+    if (pickResult === undefined) { return undefined; }
+    if (isQuickPickItem(pickResult)) {
+        return pickResult.detail;
+    }
+    if (pickResult === editButton) {
+        return await vscode.window.showInputBox({ prompt: "Enter the workflow ID" });
+    } else if (pickResult === dashboardButton) {
+        startOpenDashboardFlow(folder, cloudConfig.appName, options?.method)
+            .catch(e => logger.error("startOpenDashboard", e));
+        return undefined;
+    } else {
+        throw new Error(`Unexpected button: ${pickResult.tooltip ?? "<unknown>"}`);
     }
 }
 
-export async function deleteProvenanceDatabasePasswords() {
-    try {
-        await config.deletePasswords();
-    } catch (e) {
-        logger.error("deleteProvenanceDatabasePasswords", e);
-    }
-}
 
-export async function cloudLogin() {
-    try {
-        const folders = vscode.workspace.workspaceFolders ?? [];
-        if (folders.length === 1) {
-            await dbos_cloud_login(folders[0]);
-        } else {
-            throw new Error("This command only works when exactly one workspace folder is open");
-        }
-    } catch (e) {
-        logger.error("cloudLogin", e);
-    }
-}
 
-async function startOpenDashboardFlow(folder: vscode.WorkspaceFolder, appName: string | undefined, methodName: string, methodType: DbosMethodType): Promise<void> {
+
+
+
+
+
+
+
+
+
+
+
+
+
+async function startOpenDashboardFlow(folder: vscode.WorkspaceFolder, appName: string | undefined, method?: DbosMethodInfo): Promise<void> {
     const dashboardUrl = await dbos_cloud_dashboard_url(folder);
-    logger.debug(`startOpenDashboardFlow enter`, { folder: folder.uri.fsPath, appName: appName ?? null, methodName, methodType, dashboardUrl: dashboardUrl ?? null });
+    logger.debug(`startOpenDashboardFlow enter`, { folder: folder.uri.fsPath, appName: appName ?? null, method, dashboardUrl: dashboardUrl ?? null });
 
     if (!dashboardUrl) {
         const dashboardLaunchUrl = await dbos_cloud_dashboard_launch(folder);
@@ -165,18 +242,23 @@ async function startOpenDashboardFlow(folder: vscode.WorkspaceFolder, appName: s
         if (response === "Login") {
             logger.info(`startOpenDashboardFlow launch`, { uri: dashboardLaunchUrl });
             const openResult = await vscode.env.openExternal(vscode.Uri.parse(dashboardLaunchUrl));
-            if (!openResult) { 
-                throw new Error(`failed to open dashboard launch URL: ${dashboardLaunchUrl}`); 
+            if (!openResult) {
+                throw new Error(`failed to open dashboard launch URL: ${dashboardLaunchUrl}`);
             }
         }
     } else {
-        let query = `var-operation_name=${methodName}&var-operation_type=${methodType.toLowerCase()}`;
-        if (appName) { query += `&var-app_name=${appName}`; }
+        let query = "";
+        if (method) {
+            query += `var-operation_name=${method.name}&var-operation_type=${method.type.toLowerCase()}`;
+        }
+        if (appName) {
+            query += `&var-app_name=${appName}`;
+        }
         const dashboardQueryUrl = `${dashboardUrl}?${query}`;
         logger.info(`startOpenDashboardFlow uri`, { uri: dashboardQueryUrl });
         const openResult = await vscode.env.openExternal(vscode.Uri.parse(dashboardQueryUrl));
         if (!openResult) {
-            throw new Error(`failed to open dashboard URL: ${dashboardQueryUrl}`); 
+            throw new Error(`failed to open dashboard URL: ${dashboardQueryUrl}`);
         }
     }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,13 +24,7 @@ async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cl
                     logger.warn("startDebugging: config.getProvDBConfig returned undefined");
                     return; 
                 }
-        
-                const proxyLaunched = await debugProxy.launch(cloudConfig);
-                if (!proxyLaunched) { 
-                    logger.warn("startDebugging: debugProxy.launch returned false");
-                    return; 
-                }
-                
+               
                 const workflowID = await getWorkflowID(cloudConfig);
                 if (!workflowID) { 
                     logger.warn("startDebugging: getWorkflowID returned undefined");
@@ -43,15 +37,23 @@ async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cl
                     return;
                 }
 
+                const proxyLaunched = await debugProxy.launch(cloudConfig);
+                if (!proxyLaunched) { 
+                    logger.warn("startDebugging: debugProxy.launch returned false");
+                    return; 
+                }
+                
                 const proxyURL = `http://localhost:${config.proxyPort ?? 2345}`;
-                logger.info(`startDebugging`, { folder: folder.uri.fsPath, database: cloudConfig.database, workflowID });
+                const preLaunchTask = config.preLaunchTask;
+                logger.info(`startDebugging`, { folder: folder.uri.fsPath, database: cloudConfig.database, preLaunchTask, workflowID });
                 const debuggerStarted = await vscode.debug.startDebugging(
                     folder,
                     {
                         name: `Time-Travel Debug ${workflowID}`,
                         type: 'node-terminal',
                         request: 'launch',
-                        command: `npx dbos-sdk debug -x ${proxyURL} -u ${workflowID}`
+                        command: `npx dbos-sdk debug -x ${proxyURL} -u ${workflowID}`,
+                        preLaunchTask,
                     }
                 );
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,6 +10,7 @@ const PROV_DB_PORT = "prov_db_port";
 const PROV_DB_DATABASE = "prov_db_database";
 const PROV_DB_USER = "prov_db_user";
 const DEBUG_PROXY_PORT = "debug_proxy_port";
+const DEBUG_PRE_LAUNCH_TASK = "debug_pre_launch_task";
 
 export interface CloudConfig {
     user?: string;
@@ -46,10 +47,10 @@ async function getCloudConfigFromDbosCloud(folder: vscode.WorkspaceFolder): Prom
 function getCloudConfigFromVSCodeConfig(folder: vscode.WorkspaceFolder): CloudConfig {
     const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
 
-    const host = cfg.get<string>(PROV_DB_HOST);
-    const port = cfg.get<number>(PROV_DB_PORT);
-    const database = cfg.get<string>(PROV_DB_DATABASE);
-    const user = cfg.get<string>(PROV_DB_USER);
+    const host = cfg.get<string | undefined>(PROV_DB_HOST, undefined);
+    const port = cfg.get<number | undefined>(PROV_DB_PORT, undefined);
+    const database = cfg.get<string | undefined>(PROV_DB_DATABASE, undefined);
+    const user = cfg.get<string| undefined>(PROV_DB_USER, undefined);
 
     return {
         host: host?.length ?? 0 > 0 ? host : undefined,
@@ -90,6 +91,12 @@ export class Configuration {
     get proxyPort(): number {
         const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION);
         return cfg.get<number>(DEBUG_PROXY_PORT, 2345);
+    }
+
+    get preLaunchTask(): string | undefined {
+        const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION);
+        const value =  cfg.get<string | undefined>(DEBUG_PRE_LAUNCH_TASK, undefined);
+        return value?.length ?? 0 > 0 ? value : undefined;
     }
 
     #getPasswordKey(folder: vscode.WorkspaceFolder): string {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -44,19 +44,23 @@ async function getCloudConfigFromDbosCloud(folder: vscode.WorkspaceFolder): Prom
     }
 }
 
+function cfgString(value: string | undefined) {
+    return value?.length ?? 0 > 0 ? value : undefined;
+}
+
 function getCloudConfigFromVSCodeConfig(folder: vscode.WorkspaceFolder): CloudConfig {
     const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
 
     const host = cfg.get<string | undefined>(PROV_DB_HOST, undefined);
     const port = cfg.get<number | undefined>(PROV_DB_PORT, undefined);
     const database = cfg.get<string | undefined>(PROV_DB_DATABASE, undefined);
-    const user = cfg.get<string| undefined>(PROV_DB_USER, undefined);
+    const user = cfg.get<string | undefined>(PROV_DB_USER, undefined);
 
     return {
-        host: host?.length ?? 0 > 0 ? host : undefined,
+        host: cfgString(host),
         port: port !== 0 ? port : undefined,
-        database: database?.length ?? 0 > 0 ? database : undefined,
-        user: user?.length ?? 0 > 0 ? user : undefined,
+        database: cfgString(database),
+        user: cfgString(user),
     };
 }
 
@@ -70,13 +74,13 @@ export class Configuration {
                 const dbosConfig = await getCloudConfigFromDbosCloud(folder);
                 const localConfig = getCloudConfigFromVSCodeConfig(folder);
 
-                return <CloudConfig>{ 
-                    host: localConfig.host ?? dbosConfig?.host, 
-                    port: localConfig.port ?? dbosConfig?.port ?? 5432, 
-                    database: localConfig.database ?? dbosConfig?.database, 
-                    user: localConfig.user ?? dbosConfig?.user, 
+                return <CloudConfig>{
+                    host: localConfig.host ?? dbosConfig?.host,
+                    port: localConfig.port ?? dbosConfig?.port ?? 5432,
+                    database: localConfig.database ?? dbosConfig?.database,
+                    user: localConfig.user ?? dbosConfig?.user,
                     appName: localConfig.appName ?? dbosConfig?.appName,
-                    appId: localConfig.appId ?? dbosConfig?.appId,                    
+                    appId: localConfig.appId ?? dbosConfig?.appId,
                 };
             });
 
@@ -88,15 +92,14 @@ export class Configuration {
         }
     }
 
-    get proxyPort(): number {
-        const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION);
+    getProxyPort(folder: vscode.WorkspaceFolder): number {
+        const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
         return cfg.get<number>(DEBUG_PROXY_PORT, 2345);
     }
 
-    get preLaunchTask(): string | undefined {
-        const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION);
-        const value =  cfg.get<string | undefined>(DEBUG_PRE_LAUNCH_TASK, undefined);
-        return value?.length ?? 0 > 0 ? value : undefined;
+    getPreLaunchTask(folder: vscode.WorkspaceFolder) {
+        const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
+        return cfgString(cfg.get<string | undefined>(DEBUG_PRE_LAUNCH_TASK, undefined));
     }
 
     #getPasswordKey(folder: vscode.WorkspaceFolder): string {
@@ -125,5 +128,3 @@ export class Configuration {
         }
     }
 }
-
-

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { S3CloudStorage } from './CloudStorage';
 import { TTDbgCodeLensProvider } from './codeLensProvider';
-import { deleteProvenanceDatabasePasswords, deleteProvDbPasswordsCommandName, shutdownDebugProxyCommandName, shutdownDebugProxy, cloudLoginCommandName, cloudLogin, startDebuggingCodeLensCommandName, startDebuggingFromCodeLens, startDebuggingFromUri, startDebuggingUriCommandName } from './commands';
+import { deleteProvenanceDatabasePasswords, deleteProvDbPasswordsCommandName, shutdownDebugProxyCommandName, shutdownDebugProxy, cloudLoginCommandName, cloudLogin, startDebuggingCodeLensCommandName, startDebuggingFromCodeLens, startDebuggingFromUri, startDebuggingUriCommandName, getProxyUrl, getProxyUrlCommandName, pickWorkflowIdCommandName, pickWorkflowId } from './commands';
 import { Configuration } from './configuration';
 import { DebugProxy, } from './DebugProxy';
 import { LogOutputChannelTransport, Logger, createLogger } from './logger';
@@ -31,23 +31,20 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(debugProxy);
 
   context.subscriptions.push(
-    vscode.commands.registerCommand(startDebuggingCodeLensCommandName, startDebuggingFromCodeLens));
-  context.subscriptions.push(
-    vscode.commands.registerCommand(startDebuggingUriCommandName, startDebuggingFromUri));
-  context.subscriptions.push(
-    vscode.commands.registerCommand(shutdownDebugProxyCommandName, shutdownDebugProxy));
-  context.subscriptions.push(
-    vscode.commands.registerCommand(deleteProvDbPasswordsCommandName, deleteProvenanceDatabasePasswords));
-  context.subscriptions.push(
-    vscode.commands.registerCommand(cloudLoginCommandName, cloudLogin));
+    vscode.commands.registerCommand(cloudLoginCommandName, cloudLogin),
+    vscode.commands.registerCommand(deleteProvDbPasswordsCommandName, deleteProvenanceDatabasePasswords),
+    vscode.commands.registerCommand(shutdownDebugProxyCommandName, shutdownDebugProxy),
+    vscode.commands.registerCommand(startDebuggingCodeLensCommandName, startDebuggingFromCodeLens),
+    vscode.commands.registerCommand(startDebuggingUriCommandName, startDebuggingFromUri),
 
-  context.subscriptions.push(
+    vscode.commands.registerCommand(getProxyUrlCommandName, getProxyUrl),
+    vscode.commands.registerCommand(pickWorkflowIdCommandName, pickWorkflowId),
+
     vscode.languages.registerCodeLensProvider(
       { scheme: 'file', language: 'typescript' },
-      new TTDbgCodeLensProvider()));
-
-  context.subscriptions.push(
-    vscode.window.registerUriHandler(new TTDbgUriHandler()));
+      new TTDbgCodeLensProvider()),
+    vscode.window.registerUriHandler(new TTDbgUriHandler())
+  );
 
   await debugProxy.update().catch(e => {
     logger.error("Debug Proxy Update Failed", e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { S3CloudStorage } from './CloudStorage';
 import { TTDbgCodeLensProvider } from './codeLensProvider';
-import { deleteProvenanceDatabasePasswords, deleteProvDbPasswordsCommandName, shutdownDebugProxyCommandName, shutdownDebugProxy, cloudLoginCommandName, cloudLogin, startDebuggingCodeLensCommandName, startDebuggingFromCodeLens, startDebuggingFromUri, startDebuggingUriCommandName, getProxyUrl, getProxyUrlCommandName, pickWorkflowIdCommandName, pickWorkflowId } from './commands';
+import { deleteProvenanceDatabasePasswords, deleteProvenanceDatabasePasswordsCommandName, shutdownDebugProxyCommandName, shutdownDebugProxy, cloudLoginCommandName, cloudLogin, startDebuggingCodeLensCommandName, startDebuggingFromCodeLens, startDebuggingFromUri, startDebuggingUriCommandName, getProxyUrl, getProxyUrlCommandName, pickWorkflowIdCommandName, pickWorkflowId } from './commands';
 import { Configuration } from './configuration';
 import { DebugProxy, } from './DebugProxy';
 import { LogOutputChannelTransport, Logger, createLogger } from './logger';
@@ -32,7 +32,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand(cloudLoginCommandName, cloudLogin),
-    vscode.commands.registerCommand(deleteProvDbPasswordsCommandName, deleteProvenanceDatabasePasswords),
+    vscode.commands.registerCommand(deleteProvenanceDatabasePasswordsCommandName, deleteProvenanceDatabasePasswords),
     vscode.commands.registerCommand(shutdownDebugProxyCommandName, shutdownDebugProxy),
     vscode.commands.registerCommand(startDebuggingCodeLensCommandName, startDebuggingFromCodeLens),
     vscode.commands.registerCommand(startDebuggingUriCommandName, startDebuggingFromUri),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,56 +76,6 @@ export async function getWorkspaceFolder(rootPath?: string | vscode.Uri) {
 	return await vscode.window.showWorkspaceFolderPick();
 }
 
-export interface QuickPickOptions {
-    title?: string;
-    items?: vscode.QuickPickItem[];
-    buttons?: vscode.QuickInputButton[];
-    canSelectMany?: boolean;
-    placeHolder?: string;
-}
-
-export type QuickPickResult = vscode.QuickPickItem | vscode.QuickInputButton | undefined;
-
-export function isQuickPickItem(item: QuickPickResult): item is vscode.QuickPickItem {
-    return item !== undefined && "label" in item;
-}
-
-export async function showQuickPick(options: QuickPickOptions) {
-    const disposables: { dispose(): any }[] = [];
-    try {
-        return await new Promise<QuickPickResult>((resolve, reject) => {
-            const input = vscode.window.createQuickPick();
-            input.title = options.title;
-            input.placeholder = options.placeHolder;
-            input.canSelectMany = options.canSelectMany ?? false;
-            input.items = options.items ?? [];
-            input.buttons = options.buttons ?? [];
-
-            disposables.push(
-                input.onDidTriggerButton(async (button) => {
-                    resolve(button);
-                    input.hide();
-                }),
-                input.onDidChangeSelection(items => {
-                    const item = items[0];
-                    if (item) {
-                        resolve(item);
-                        input.hide();
-                    }
-                }),
-                input.onDidHide(() => {
-                    resolve(undefined);
-                    input.dispose();
-                }),
-            );
-
-            input.show();
-        });
-    } finally {
-        disposables.forEach(d => d.dispose());
-    }
-}
-
 export interface ExecFileError {
     cmd: string;
     code: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,9 +50,21 @@ export function hashClientConfig(clientConfig: ClientConfig | CloudConfig) {
         : undefined;
 }
 
-export async function getWorkspaceFolder() {
+export async function getWorkspaceFolder(rootPath?: string | vscode.Uri) {
+    if (rootPath) { 
+        if (typeof rootPath === "string") { 
+            rootPath = vscode.Uri.file(rootPath); 
+        }
+        const folder = vscode.workspace.getWorkspaceFolder(rootPath);
+        if (folder) { 
+            return folder; 
+        }
+    }
+
     const folders = vscode.workspace.workspaceFolders ?? [];
-    if (folders.length === 1) { return folders[0]; }
+    if (folders.length === 1) { 
+        return folders[0]; 
+    }
 
 	if (vscode.window.activeTextEditor) {
 		const folder = vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri);
@@ -60,6 +72,7 @@ export async function getWorkspaceFolder() {
 			return folder;
 		}
 	}
+
 	return await vscode.window.showWorkspaceFolderPick();
 }
 


### PR DESCRIPTION
This PR adds a new config setting `debug_pre_launch_task`. whatever value is specifed for this config setting will be passed to the TT Debug configuration launched by the code lens. If this is a string that matches an existing named task in tasks.json, it will be run before debugging.

Note, I'm looking at a how we might leverage existing launch.json to specify this, but I'm still researching.