### PR TITLE
last minute fixes

### DIFF
--- a/src/DebugProxy.ts
+++ b/src/DebugProxy.ts
@@ -46,7 +46,7 @@ export class DebugProxy {
         }
     }
 
-    async launch(clientConfig: CloudConfig): Promise<boolean> {
+    async launch(clientConfig: CloudConfig, folder: vscode.WorkspaceFolder): Promise<boolean> {
         const configHash = hashClientConfig(clientConfig);
 
         if (!configHash) { throw new Error("Invalid configuration"); }
@@ -58,7 +58,7 @@ export class DebugProxy {
             throw new Error("Debug proxy not installed");
         }
 
-        const proxy_port = config.proxyPort;
+        const proxy_port = config.getProxyPort(folder);
         let { host, port, database, user, password } = clientConfig;
         if (typeof password === "function") { 
             const $password = await password();

--- a/src/DebugProxy.ts
+++ b/src/DebugProxy.ts
@@ -190,9 +190,13 @@ export class DebugProxy {
         }
     }
 
-    async _getRemoteVersion(token?: vscode.CancellationToken) {
+    async _getRemoteVersion(includePrerelease?: boolean, token?: vscode.CancellationToken) {
+        includePrerelease = includePrerelease ?? false;
         let latestVersion: string | undefined = undefined;
         for await (const version of this.cloudStorage.getVersions(token)) {
+            if (semver.prerelease(version) && !includePrerelease) {
+                continue;
+            }
             if (latestVersion === undefined || semver.gt(version, latestVersion)) {
                 latestVersion = version;
             }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,7 +50,7 @@ export async function getProxyUrl(cfg?: vscode.DebugConfiguration) {
             throw new Error(`Failed to get cloud config`, { cause: folder.uri.fsPath });
         }
 
-        const proxyLaunched = await debugProxy.launch(cloudConfig);
+        const proxyLaunched = await debugProxy.launch(cloudConfig, folder);
         if (!proxyLaunched) {
             throw new Error("Failed to launch debug proxy", { cause: cloudConfig });
         }
@@ -133,7 +133,7 @@ async function startDebugging(folder: vscode.WorkspaceFolder, getWorkflowID: (cl
                 return undefined;
             }
 
-            const proxyLaunched = await debugProxy.launch(cloudConfig);
+            const proxyLaunched = await debugProxy.launch(cloudConfig, folder);
             if (!proxyLaunched) {
                 logger.warn("startDebugging: debugProxy.launch returned false", { folder: folder.uri.fsPath, cloudConfig, workflowID });
                 return undefined;


### PR DESCRIPTION
* Fix getProxyPort in debug proxy launch (not clear why this isn't a build error)
* Filter out pre-release debug proxy builds by default