### PR TITLE
remove launch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,6 @@
         "category": "DBOS"
       },
       {
-        "command": "dbos-ttdbg.launch-dbos-app",
-        "title": "Launch DBOS Application",
-        "category": "DBOS",
-        "icon": "$(globe)"
-      },
-      {
         "command": "dbos-ttdbg.shutdown-debug-proxy",
         "title": "Shutdown Debug Proxy",
         "category": "DBOS"
@@ -98,11 +92,6 @@
         {
           "command": "dbos-ttdbg.delete-app-db-password",
           "when": "view == dbos-ttdbg.views.resources && viewItem == cloudApp"
-        },
-        {
-          "command": "dbos-ttdbg.launch-dbos-app",
-          "when": "view == dbos-ttdbg.views.resources && viewItem == cloudApp",
-          "group": "inline"
         }
       ]
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -65,21 +65,6 @@ export async function deleteStoredPasswords() {
   }
 }
 
-export const launchDbosAppCommandName = "dbos-ttdbg.launch-dbos-app";
-export async function launchDbosApp(node?: CloudAppNode) {
-  logger.debug("launchDbosApp", { node: node ?? null });
-  if (node) {
-    try {
-      const opened = await vscode.env.openExternal(vscode.Uri.parse(node.app.AppURL));
-      if (!opened) {
-        vscode.window.showErrorMessage(`Failed to open ${node.app.Name} app`);
-      }
-    } catch (e) {
-      logger.error("launchDbosApp", e);
-    }
-  }
-}
-
 export const getProxyUrlCommandName = "dbos-ttdbg.get-proxy-url";
 export async function getProxyUrl(cfg?: vscode.DebugConfiguration & { rootPath?: string }) {
   try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { S3CloudStorage } from './CloudStorage';
 import { TTDbgCodeLensProvider } from './codeLensProvider';
-import { deleteStoredPasswords, deleteStoredPasswordsCommandName, shutdownDebugProxyCommandName, shutdownDebugProxy, cloudLoginCommandName, cloudLogin, startDebuggingCodeLensCommandName, startDebuggingFromCodeLens, startDebuggingFromUri, startDebuggingUriCommandName, getProxyUrl, getProxyUrlCommandName, pickWorkflowIdCommandName, pickWorkflowId, deleteDomainCredentials, deleteDomainCredentialsCommandName, deleteAppDatabasePassword, deleteAppDatabasePasswordCommandName, launchDbosApp, launchDbosAppCommandName } from './commands';
+import { deleteStoredPasswords, deleteStoredPasswordsCommandName, shutdownDebugProxyCommandName, shutdownDebugProxy, cloudLoginCommandName, cloudLogin, startDebuggingCodeLensCommandName, startDebuggingFromCodeLens, startDebuggingFromUri, startDebuggingUriCommandName, getProxyUrl, getProxyUrlCommandName, pickWorkflowIdCommandName, pickWorkflowId, deleteDomainCredentials, deleteDomainCredentialsCommandName, deleteAppDatabasePassword, deleteAppDatabasePasswordCommandName } from './commands';
 import { Configuration } from './configuration';
 import { DebugProxy, } from './DebugProxy';
 import { LogOutputChannelTransport, Logger, createLogger } from './logger';
@@ -36,7 +36,6 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(deleteDomainCredentialsCommandName, deleteDomainCredentials),
     vscode.commands.registerCommand(deleteAppDatabasePasswordCommandName, deleteAppDatabasePassword),
     vscode.commands.registerCommand(deleteStoredPasswordsCommandName, deleteStoredPasswords),
-    vscode.commands.registerCommand(launchDbosAppCommandName, launchDbosApp),
     vscode.commands.registerCommand(shutdownDebugProxyCommandName, shutdownDebugProxy),
     vscode.commands.registerCommand(startDebuggingCodeLensCommandName, startDebuggingFromCodeLens),
     vscode.commands.registerCommand(startDebuggingUriCommandName, startDebuggingFromUri),


### PR DESCRIPTION
The live demo DBOS app has a user facing web site, but that's not expected to be common. So there's no use for this command in the UI