### PR TITLE
Update URL protocol and dbos command

### DIFF
--- a/src/commands/getProxyUrl.ts
+++ b/src/commands/getProxyUrl.ts
@@ -15,7 +15,7 @@ export async function getProxyUrl(cfg?: vscode.DebugConfiguration & { rootPath?:
     if (!proxyLaunched) {
       throw new Error("Failed to launch debug proxy", { cause: { folder: folder.uri.fsPath, debugConfig } });
     }
-    return `http://localhost:${config.getProxyPort(folder)}`;
+    return `http://127.0.0.1:${config.getProxyPort(folder)}`;
   } catch (e) {
     logger.error("getProxyUrl", e);
     vscode.window.showErrorMessage(`Failed to get proxy URL`);

--- a/src/commands/getProxyUrl.ts
+++ b/src/commands/getProxyUrl.ts
@@ -15,7 +15,7 @@ export async function getProxyUrl(cfg?: vscode.DebugConfiguration & { rootPath?:
     if (!proxyLaunched) {
       throw new Error("Failed to launch debug proxy", { cause: { folder: folder.uri.fsPath, debugConfig } });
     }
-    return `postgresql://127.0.0.1:${config.getProxyPort(folder)}`;
+    return `postgresql://localhost:${config.getProxyPort(folder)}`;
   } catch (e) {
     logger.error("getProxyUrl", e);
     vscode.window.showErrorMessage(`Failed to get proxy URL`);

--- a/src/commands/getProxyUrl.ts
+++ b/src/commands/getProxyUrl.ts
@@ -15,7 +15,7 @@ export async function getProxyUrl(cfg?: vscode.DebugConfiguration & { rootPath?:
     if (!proxyLaunched) {
       throw new Error("Failed to launch debug proxy", { cause: { folder: folder.uri.fsPath, debugConfig } });
     }
-    return `http://127.0.0.1:${config.getProxyPort(folder)}`;
+    return `postgresql://127.0.0.1:${config.getProxyPort(folder)}`;
   } catch (e) {
     logger.error("getProxyUrl", e);
     vscode.window.showErrorMessage(`Failed to get proxy URL`);

--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -72,7 +72,7 @@ function getDebugLaunchConfig(folder: vscode.WorkspaceFolder, workflowID: string
     name: `Time-Travel Debug ${workflowID}`,
     type: 'node-terminal',
     request: 'launch',
-    command: `npx dbos-sdk debug -x http://127.0.0.1:${proxyPort} -u ${workflowID}`,
+    command: `npx dbos-sdk debug -x postgresql://127.0.0.1:${proxyPort} -u ${workflowID}`,
     preLaunchTask,
   };
 }

--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -60,7 +60,7 @@ function getDebugLaunchConfig(folder: vscode.WorkspaceFolder, workflowID: string
   const debugConfigs = vscode.workspace.getConfiguration("launch", folder).get('configurations') as ReadonlyArray<vscode.DebugConfiguration> | undefined;
   for (const config of debugConfigs ?? []) {
     const command = config["command"] as string | undefined;
-    if (command && command.includes("npx dbos-sdk debug")) {
+    if (command && command.includes("npx dbos debug")) {
       const newCommand = command.replace("${command:dbos-ttdbg.pick-workflow-id}", `${workflowID}`);
       return { ...config, command: newCommand };
     }
@@ -72,7 +72,7 @@ function getDebugLaunchConfig(folder: vscode.WorkspaceFolder, workflowID: string
     name: `Time-Travel Debug ${workflowID}`,
     type: 'node-terminal',
     request: 'launch',
-    command: `npx dbos-sdk debug -x postgresql://127.0.0.1:${proxyPort} -u ${workflowID}`,
+    command: `npx dbos debug -x postgresql://localhost:${proxyPort} -u ${workflowID}`,
     preLaunchTask,
   };
 }

--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -72,7 +72,7 @@ function getDebugLaunchConfig(folder: vscode.WorkspaceFolder, workflowID: string
     name: `Time-Travel Debug ${workflowID}`,
     type: 'node-terminal',
     request: 'launch',
-    command: `npx dbos-sdk debug -x http://localhost:${proxyPort} -u ${workflowID}`,
+    command: `npx dbos-sdk debug -x http://127.0.0.1:${proxyPort} -u ${workflowID}`,
     preLaunchTask,
   };
 }


### PR DESCRIPTION
The ECONNREFUSED issue here https://github.com/dbos-inc/dbos-transact/issues/488 seems to be caused by the system trying to use IPv6 to connect to the proxy.

Since the proxy always listens at an IPv4 address (127.0.0.1), it would be more robust to explicitly specify it.