### PR TITLE
look for launch config with `npx dbos debug` OR `npx dbos-sdk debug`

### DIFF
--- a/src/startDebugging.ts
+++ b/src/startDebugging.ts
@@ -60,7 +60,9 @@ function getDebugLaunchConfig(folder: vscode.WorkspaceFolder, workflowID: string
   const debugConfigs = vscode.workspace.getConfiguration("launch", folder).get('configurations') as ReadonlyArray<vscode.DebugConfiguration> | undefined;
   for (const config of debugConfigs ?? []) {
     const command = config["command"] as string | undefined;
-    if (command && command.includes("npx dbos debug")) {
+    if (command 
+      && (command.includes("npx dbos debug") || command.includes("npx dbos-sdk debug"))
+    ) {
       const newCommand = command.replace("${command:dbos-ttdbg.pick-workflow-id}", `${workflowID}`);
       return { ...config, command: newCommand };
     }


### PR DESCRIPTION
When launching the TT debugger, we look for an existing launch configuration containing `npx dbos debug`. However, DBOS also supports useing the `dbos-sdk` cli command. So this PR updates the extension to look use the first launch configuration with either `npx dbos debug` or `npx dbos-sdk debug` in the command