### PR TITLE
New extension settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,15 @@
           "type": "number",
           "default": 2345
         },
+        "dbos-ttdbg.debug_proxy_path": {
+          "type": "string",
+          "description": "Path to the debug proxy executable. Overrides downloading the latest version of the debug proxy."
+        },
+        "dbos-ttdbg.debug_proxy_launch": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically launch the debug proxy when debugging."
+        },
         "dbos-ttdbg.prov_db_database": {
           "type": "string"
         },

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -11,6 +11,19 @@ const PROV_DB_DATABASE = "prov_db_database";
 const PROV_DB_USER = "prov_db_user";
 const DEBUG_PROXY_PORT = "debug_proxy_port";
 const DEBUG_PRE_LAUNCH_TASK = "debug_pre_launch_task";
+const DEBUG_PROXY_PATH = "debug_proxy_path";
+const DEBUG_PROXY_LAUNCH = "debug_proxy_launch";
+
+export function getLaunchProxyConfig() {
+  const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION);
+  return cfg.get<boolean>(DEBUG_PROXY_LAUNCH, true);
+}
+
+export function getProxyPathConfig() {
+  const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION);
+  const proxyPath = cfg.get<string>(DEBUG_PROXY_PATH);
+  return proxyPath ? vscode.Uri.file(proxyPath) : undefined;
+}
 
 export interface DbosDebugConfig {
   user: string;


### PR DESCRIPTION
add extension settings, primarily to enable debugging the debug proxy itself

* `dbos-ttdbg.debug_proxy_path`: use a specific local path to the debug proxy instead of downloading most recent build from the cloud
* `dbos-ttdbg.debug_proxy_launch`: defaults to true, but can be used to disable proxy launch. Usefull when launching the debug proxy under the debugger