### PR TITLE
Assorted Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ this project uses *EVEN* minor version numbers for release versions and *ODD* mi
 * Added `Browse DBOS Cloud App` command to navigate to a selected DBOS cloud application
 * Added `debug_proxy_prerelease` configuration setting, to support automatically installing prerelease versions of the Time Travel Debug Proxy
 * added `just_my_code` configuration setting, to control [`justMyCode`](https://code.visualstudio.com/docs/python/debugging#_justmycode) Python debugger setting
+* Added `time_travel_code_lens_enabled` configuration setting
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
       }
     ],
     "configuration": {
-      "title": "DBOS Time Travel Debugger",
+      "title": "DBOS Debugger",
       "properties": {
         "dbos-ttdbg.debug_proxy_port": {
           "type": "number",
@@ -70,6 +70,11 @@
           "type": "boolean",
           "default": true,
           "description": "Only show frames from the user's code in the call stack when debugging."
+        },
+        "dbos-ttdbg.time_travel_code_lens_enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable Time Travel Debugging Code Lens."
         }
       }
     },

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -184,14 +184,15 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     }));
                 }
 
-                if (timeTravel) {
-                    lenses.push(new vscode.CodeLens(range, {
-                        title: '⏳ Time-Travel Debug',
-                        tooltip: `Debug ${name} with the time travel debugger`,
-                        command: startDebuggingCodeLensCommandName,
-                        arguments: [name, config, timeTravel]
-                    }));
-                }
+                // TODO: re-enable time-travel debugging after ts/py transact are fixed
+                // if (timeTravel) {
+                //     lenses.push(new vscode.CodeLens(range, {
+                //         title: '⏳ Time-Travel Debug',
+                //         tooltip: `Debug ${name} with the time travel debugger`,
+                //         command: startDebuggingCodeLensCommandName,
+                //         arguments: [name, config, timeTravel]
+                //     }));
+                // }
             }
             return lenses;
         } catch (e) {
@@ -306,7 +307,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
 
     #getDebugConfig(workflowID: string, config: DbosConfig, cloudLensInfo: CloudLensInfo | undefined): vscode.DebugConfiguration | undefined {
         const language = config.language ?? "node";
-        switch (config.language) {
+        switch (language) {
             case "node": return this.#getNodeDebugConfig(workflowID, config, cloudLensInfo);
             case "python": return this.#getPythonDebugConfig(workflowID, config, cloudLensInfo);
             default: throw new Error(`Unsupported language: ${language}`);
@@ -339,6 +340,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             cwd: path.dirname(config.uri.fsPath),
             justMyCode: Configuration.getJustMyCode(),
             env: {
+                DBOS_DEBUG_TIME_TRAVEL: timeTravel ? "true" : undefined,
                 DBOS_DBHOST: timeTravel ? "localhost" : cloudLensInfo?.host,
                 DBOS_DBPORT: timeTravel ? undefined : cloudLensInfo?.port.toString(),
                 DBOS_DBUSER: timeTravel ? undefined : cloudLensInfo?.user,
@@ -361,6 +363,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             cwd: path.dirname(config.uri.fsPath),
             env: {
                 DBOS_DEBUG_WORKFLOW_ID: workflowID,
+                DBOS_DEBUG_TIME_TRAVEL: timeTravel ? "true" : undefined,
                 DBOS_DBHOST: timeTravel ? "localhost" : cloudLensInfo?.host,
                 DBOS_DBPORT: timeTravel ? undefined : cloudLensInfo?.port.toString(),
                 DBOS_DBUSER: timeTravel ? undefined : cloudLensInfo?.user,
@@ -368,6 +371,12 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                 DBOS_DBLOCALSUFFIX: (timeTravel || cloudLensInfo) ? "false" : undefined,
             }
         };
+        
+        if (Configuration.getJustMyCode()) {
+            const nodeInternals = "<node_internals>/**";
+            const nodeModules = path.join(path.dirname(config.uri.fsPath), "node_modules", "**", "*.js");
+            debugConfig.skipFiles = [nodeInternals, nodeModules];
+        }
 
         const start = config.runtime?.start ?? [];
         if (start.length === 0) {

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -372,7 +372,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
         };
         
         if (Configuration.getJustMyCode()) {
-            const nodeInternals = "<node_internals>/**";
+            const nodeInternals = "<node_internals>/**/*.js";
             const nodeModules = path.join(path.dirname(config.uri.fsPath), "node_modules", "**", "*.js");
             debugConfig.skipFiles = [nodeInternals, nodeModules];
         }

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -184,15 +184,14 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     }));
                 }
 
-                // TODO: re-enable time-travel debugging after ts/py transact are fixed
-                // if (timeTravel) {
-                //     lenses.push(new vscode.CodeLens(range, {
-                //         title: '⏳ Time-Travel Debug',
-                //         tooltip: `Debug ${name} with the time travel debugger`,
-                //         command: startDebuggingCodeLensCommandName,
-                //         arguments: [name, config, timeTravel]
-                //     }));
-                // }
+                if (timeTravel && Configuration.getTimeTravelCodeLensEnabled()) {
+                    lenses.push(new vscode.CodeLens(range, {
+                        title: '⏳ Time-Travel Debug',
+                        tooltip: `Debug ${name} with the time travel debugger`,
+                        command: startDebuggingCodeLensCommandName,
+                        arguments: [name, config, timeTravel]
+                    }));
+                }
             }
             return lenses;
         } catch (e) {

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -5,6 +5,7 @@ const DEBUG_PROXY_PORT = "debug_proxy_port";
 const DEBUG_PROXY_PATH = "debug_proxy_path";
 const DEBUG_PROXY_PRERELEASE = "debug_proxy_prerelease";
 const DEBUG_JUST_MY_CODE = "just_my_code";
+const DEBUG_TIME_TRAVEL_CODE_LENS = "time_travel_code_lens_enabled";
 
 export class Configuration {
 
@@ -27,5 +28,10 @@ export class Configuration {
     static getJustMyCode(folder?: vscode.WorkspaceFolder) {
         const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
         return cfg.get<boolean>(DEBUG_JUST_MY_CODE, true);
+    }
+
+    static getTimeTravelCodeLensEnabled(folder?: vscode.WorkspaceFolder) {
+        const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
+        return cfg.get<boolean>(DEBUG_TIME_TRAVEL_CODE_LENS, false);
     }
 }


### PR DESCRIPTION
* Added a time travel code lens enabled configuration setting, defaults to `false`
* fixed language switch in CodeLensProvider.#getDebugConfig
* added DBOS_DEBUG_TIME_TRAVEL env to debug config when appropriate
* add node internals and node modules to node debug config [skipFiles](https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_skipping-uninteresting-code) 