### PR TITLE
swap label and detail of WF quick pick

### DIFF
--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -52,12 +52,13 @@ async function pickWorkflow(client: ClientBase, methodName: string) {
         "SELECT * FROM dbos.workflow_status WHERE (status = 'SUCCESS' OR status = 'ERROR') AND name = $1 ORDER BY created_at DESC",
         [methodName]);
     const items = result.rows.map(status => {
-        const $createdAt = BigInt(status.created_at);
-        const createdAt = $createdAt <= BigInt(Number.MAX_SAFE_INTEGER) ? new Date(Number($createdAt)) : undefined;
+        const createdAt = new Date(Number(status.created_at)).toLocaleString();
         return <vscode.QuickPickItem>{
-            label: createdAt?.toLocaleString() ?? "unknown",
-            description: `${status.status}${status.authenticated_user && status.authenticated_user.length !== 0 ? ` (${status.authenticated_user})` : ""}`,
-            detail: status.workflow_uuid,
+            label: status.workflow_uuid,
+            description: `${status.status}`,
+            detail: status.authenticated_user && status.authenticated_user.length !== 0
+                ? `at ${createdAt} by ${status.authenticated_user}`
+                : `at ${createdAt}`
         };
     });
 


### PR DESCRIPTION
changed the workflow picker to use the WF ID as the `label` and the date + authenticated user as the `detail`. VSCode uses the label value for filtering, so it makes sense to have the label be the WF ID. ALso, was cleaner to move the authenticated user (if present) to the detail line along with the date.

New Picker: 

![image](https://github.com/user-attachments/assets/c00aba85-f8d5-47fd-b1c4-35a6a4e02c65)

Previous Picker:

![image](https://github.com/user-attachments/assets/ee46fd75-8cde-4fed-bddf-8fcfb1f0f87c)

Also, removed the check for created_at against Number.MAX_SAFE_INTEGER. The largest viable date value is 28487 years in the future. I don't expect to be supporting this code in the year <checks notes> 30512.