### PR TITLE
Devhawk/update-debug-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning](https://semver.org) and uses
 As per [VSCode recommendation](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions),
 this project uses *EVEN* minor version numbers for release versions and *ODD* minor version numbers for pre-release versions,
 
+## Unreleased
+
+### Changed
+
+* `time_travel_code_lens_enabled` configuration setting defaults to true
+* `Time-Travel Debug` CodeLens only supported in TypeScript
+* Reworked generated TypeScript debug config to match TS Time Travel Debug Mode as implemented in https://github.com/dbos-inc/dbos-transact-ts/pull/786
+
 ## [2.0] 2025-03-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         },
         "dbos-ttdbg.time_travel_code_lens_enabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable Time Travel Debugging Code Lens."
         }
       }

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -275,22 +275,18 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             logger.info("codeLensDebug", { workflowID: workflowID ?? null });
             if (!workflowID) { return; }
 
-
             const debugConfig = $this.#getDebugConfig(workflowID, config, cloudLensInfo);
             logger.info("startDebuggingFromCodeLens", { debugConfig: debugConfig ?? null });
             if (!debugConfig) { return; }
 
-            if (cloudLensInfo && (cloudLensInfo.timeTravel ?? false)) {
-                const proxyPort = Configuration.getProxyPort();
-                debugConfig.env["DBOS_DBPORT"] = proxyPort.toString();
-
+            if (cloudLensInfo?.timeTravel === true) {
                 $this.debugProxyManager.launchDebugProxy({
                     host: cloudLensInfo.host,
                     port: cloudLensInfo.port,
                     user: cloudLensInfo.user,
                     password: cloudLensInfo.password,
                     database: cloudLensInfo.database,
-                    proxyPort
+                    proxyPort: Configuration.getProxyPort()
                 });
 
             }

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -185,7 +185,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     }));
                 }
 
-                if (timeTravel && Configuration.getTimeTravelCodeLensEnabled()) {
+                if (timeTravel && document.languageId === 'typescript' && Configuration.getTimeTravelCodeLensEnabled()) {
                     lenses.push(new vscode.CodeLens(range, {
                         title: '⏳ Time-Travel Debug',
                         tooltip: `Debug ${name} with the time travel debugger`,
@@ -320,6 +320,12 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             throw new Error(`Expected python language, received ${config.language ?? null}`);
         }
 
+        const timeTravel = cloudLensInfo?.timeTravel ?? false;
+        if (timeTravel)  {
+            vscode.window.showErrorMessage("Python does not support time travel debugging at this time");
+            return undefined;
+        }
+
         const ext = vscode.extensions.getExtension("ms-python.debugpy");
         if (!ext) {
             vscode.window.showErrorMessage("Python debugger not found. Please install the Python extension for VSCode.", "Install", "Cancel")
@@ -331,7 +337,6 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             return undefined;
         }
 
-        const timeTravel = cloudLensInfo?.timeTravel ?? false;
         const debugConfig: vscode.DebugConfiguration = {
             type: 'debugpy',
             request: 'launch',

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -331,7 +331,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             return undefined;
         }
 
-        const timeTravel = cloudLensInfo?.timeTravel ?? false;
+        // const timeTravel = cloudLensInfo?.timeTravel ?? false;
         return {
             type: 'debugpy',
             request: 'launch',
@@ -340,14 +340,14 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             args: ['debug', workflowID],
             cwd: path.dirname(config.uri.fsPath),
             justMyCode: Configuration.getJustMyCode(),
-            env: {
-                DBOS_DEBUG_TIME_TRAVEL: timeTravel ? "true" : undefined,
-                DBOS_DBHOST: timeTravel ? "localhost" : cloudLensInfo?.host,
-                DBOS_DBPORT: timeTravel ? undefined : cloudLensInfo?.port.toString(),
-                DBOS_DBUSER: timeTravel ? undefined : cloudLensInfo?.user,
-                DBOS_DBPASSWORD: timeTravel ? undefined : cloudLensInfo?.password,
-                DBOS_DBLOCALSUFFIX: (timeTravel || cloudLensInfo) ? "false" : undefined,
-            }
+            // env: {
+            //     DBOS_DEBUG_TIME_TRAVEL: timeTravel ? "true" : undefined,
+            //     DBOS_DBHOST: timeTravel ? "localhost" : cloudLensInfo?.host,
+            //     DBOS_DBPORT: timeTravel ? undefined : cloudLensInfo?.port.toString(),
+            //     DBOS_DBUSER: timeTravel ? undefined : cloudLensInfo?.user,
+            //     DBOS_DBPASSWORD: timeTravel ? undefined : cloudLensInfo?.password,
+            //     DBOS_DBLOCALSUFFIX: (timeTravel || cloudLensInfo) ? "false" : undefined,
+            // }
         };
     }
 
@@ -375,7 +375,6 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                 DBOS_DBHOST: "localhost",
                 DBOS_DBPORT: `${Configuration.getProxyPort()}`,
                 DBOS_DBLOCALSUFFIX: "false",
-                DBOS_DEBUG_TIME_TRAVEL:"true",
             }
         } else if (cloudLensInfo) {
             debugConfig.env = { 
@@ -402,6 +401,9 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             debugConfig.runtimeExecutable = args[0];
             debugConfig.args = args.slice(1);
             debugConfig.env.DBOS_DEBUG_WORKFLOW_ID = workflowID;
+            if (timeTravel) {
+                debugConfig.env.DBOS_DEBUG_TIME_TRAVEL = "true";
+            }
         }
         else {
             throw new Error("multiple runtimeConfig.start command support not implemented");

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -32,6 +32,6 @@ export class Configuration {
 
     static getTimeTravelCodeLensEnabled(folder?: vscode.WorkspaceFolder) {
         const cfg = vscode.workspace.getConfiguration(TTDBG_CONFIG_SECTION, folder);
-        return cfg.get<boolean>(DEBUG_TIME_TRAVEL_CODE_LENS, false);
+        return cfg.get<boolean>(DEBUG_TIME_TRAVEL_CODE_LENS, true);
     }
 }


### PR DESCRIPTION
* flip time_travel_code_lens_enabled config to default true
* only show TT dbg code lens for TypeScript files
* fail in getPythonDebugConfig if TT dbg is enabled
* Rework #getNodeDebugConfig to match https://github.com/dbos-inc/dbos-transact-ts/pull/786

