### PR TITLE
DBOS Cloud Console Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ this project uses *EVEN* minor version numbers for release versions and *ODD* mi
 
 ## Unreleased
 
+### Added
+
+* DBOS Cloud Console integration for workflow picker in cloud replay and time travel debugging scenarios.
+
 ### Changed
 
 * `time_travel_code_lens_enabled` configuration setting defaults to true
@@ -79,6 +83,8 @@ this project uses *EVEN* minor version numbers for release versions and *ODD* mi
 - Added custom `prep-release.mjs` script that implements `nbgv prepare-release` but using this project's
   [version numbering strategy](https://github.com/dbos-inc/ttdbg-extension?tab=readme-ov-file#versioning-strategy).
 
+
+
 ## [1.0.9] 2024-03-19
 
 ### Fixed
@@ -88,6 +94,8 @@ this project uses *EVEN* minor version numbers for release versions and *ODD* mi
 ### Engineering
 
 - Updated `softprops/action-gh-release` action to v2.0.2 and fixed commit tagged for the release.
+
+
 
 ## [1.0.5] 2024-03-18
 
@@ -99,9 +107,13 @@ this project uses *EVEN* minor version numbers for release versions and *ODD* mi
 - Simplified launching the DBOS Cloud Dashboard to silently call `createDashboard` if `getDashboard` returns undefined. 
   Previously, undefined `getDashboard` would launch the `createDashboard` url but cancel launching the debugger.
 
+
+
 ## [1.0] 2024-03-12
 
 - Initial release
+
+
 
 ## [0.9] 2024-02-28
 

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -443,7 +443,8 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     // vscode.env.openExternal(navigateUri).then(undefined, error => logger.error("openExternal", error));
 
                     // TODO: remove directly opening the callback URI with the hard coded wf id
-                    const demoUri = vscode.Uri.parse(`${callbackUri}&workflow_id=${items[0].label}`);
+                    const randomIndex = Math.floor(Math.random() * items.length);
+                    const demoUri = vscode.Uri.parse(`${callbackUri}&workflow_id=${items[randomIndex].label}`);
                     vscode.env.openExternal(demoUri);
 
                     return undefined;

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -438,15 +438,9 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     const debugUri =  vscode.Uri.parse(`${vscode.env.uriScheme}://${extensionId}/${path}?app_name=${config.name}`);
                     const callbackUri = await vscode.env.asExternalUri(debugUri);
 
-                    // TODO: remove staging from hard coded URL
-                    const navigateUri = vscode.Uri.parse(`https://staging.console.dbos.dev/applications/${config.name}/workflows?workflow_name=${methodName}&callback_uri=${encodeURI(callbackUri.toString())}`);
+                    const navigateUri = vscode.Uri.parse(`https://console.dbos.dev/applications/${config.name}/workflows?workflow_name=${methodName}&callback_uri=${encodeURI(callbackUri.toString())}`);
                     vscode.env.openExternal(navigateUri)
                         .then(undefined, error => logger.error("openExternal", { error, navigateUri: navigateUri.toString() }));
-
-                    // TODO: remove directly opening the callback URI with the hard coded wf id
-                    // const randomIndex = Math.floor(Math.random() * items.length);
-                    // const demoUri = vscode.Uri.parse(`${callbackUri}&workflow_id=${items[randomIndex].label}`);
-                    // vscode.env.openExternal(demoUri);
 
                     return undefined;
                 }

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -438,14 +438,15 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     const debugUri =  vscode.Uri.parse(`${vscode.env.uriScheme}://${extensionId}/${path}?app_name=${config.name}`);
                     const callbackUri = await vscode.env.asExternalUri(debugUri);
 
-                    // TODO: uncomment navigation to console URI
-                    // const navigateUri = vscode.Uri.parse(`https://console.dbos.dev/applications/${config.name}/workflows?workflow_name=${methodName}&callback_uri=${encodeURI(callbackUri.toString())}`);
-                    // vscode.env.openExternal(navigateUri).then(undefined, error => logger.error("openExternal", error));
+                    // TODO: remove staging from hard coded URL
+                    const navigateUri = vscode.Uri.parse(`https://staging.console.dbos.dev/applications/${config.name}/workflows?workflow_name=${methodName}&callback_uri=${encodeURI(callbackUri.toString())}`);
+                    vscode.env.openExternal(navigateUri)
+                        .then(undefined, error => logger.error("openExternal", { error, navigateUri: navigateUri.toString() }));
 
                     // TODO: remove directly opening the callback URI with the hard coded wf id
-                    const randomIndex = Math.floor(Math.random() * items.length);
-                    const demoUri = vscode.Uri.parse(`${callbackUri}&workflow_id=${items[randomIndex].label}`);
-                    vscode.env.openExternal(demoUri);
+                    // const randomIndex = Math.floor(Math.random() * items.length);
+                    // const demoUri = vscode.Uri.parse(`${callbackUri}&workflow_id=${items[randomIndex].label}`);
+                    // vscode.env.openExternal(demoUri);
 
                     return undefined;
                 }

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -9,27 +9,7 @@ import { Configuration } from './Configuration';
 import { parseTypeScript } from './parsers/tsParser';
 import { parsePython } from './parsers/pyParser';
 import path from 'path';
-
-interface workflow_status {
-    workflow_uuid: string;
-    status: string | null;
-    name: string | null;
-    authenticated_user: string | null;
-    assumed_role: string | null;
-    authenticated_roles: string | null;
-    request: string | null;
-    output: string | null;
-    error: string | null;
-    executor_id: string | null;
-    created_at: string;                 // actually a bigint
-    updated_at: string;                 // actually a bigint
-    application_version: string | null;
-    application_id: string | null;
-    class_name: string | null;
-    config_name: string | null;
-    recovery_attempts: string | null;   // actually a nullable bigint
-    queue_name: string | null;
-}
+import type { workflow_status } from './dbosTables';
 
 export interface DbosWorkflowMethod {
     name: string;

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -73,7 +73,8 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             const parser = getParser(document.languageId);
             if (!parser) { return []; }
 
-            const config = await this.#getConfig(document.uri, token);
+            const configUri = await locateDbosConfigFile(document.uri);
+            const config =  configUri ? await loadConfigFile(configUri, token) : undefined;
             if (!config) { return []; }
 
             const { cloudRelay, timeTravel } = await this.#getCloudLensInfo(config, token);
@@ -120,11 +121,6 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                 default: return undefined;
             }
         }
-    }
-
-    async #getConfig(uri: vscode.Uri, token?: vscode.CancellationToken): Promise<DbosConfig | undefined> {
-        const configUri = await locateDbosConfigFile(uri);
-        return configUri ? await loadConfigFile(configUri, token) : undefined;
     }
 
     async #getCloudLensInfo(config: DbosConfig, token?: vscode.CancellationToken): Promise<{ cloudRelay?: CloudLensInfo; timeTravel?: CloudLensInfo; }> {

--- a/src/CodeLensProvider.ts
+++ b/src/CodeLensProvider.ts
@@ -80,7 +80,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             if (!parser) { return []; }
 
             const configUri = await locateDbosConfigFile(document.uri);
-            const config =  configUri ? await loadConfigFile(configUri, token) : undefined;
+            const config = configUri ? await loadConfigFile(configUri, token) : undefined;
             if (!config) { return []; }
 
             const { cloudRelay, timeTravel } = await this.#getCloudConnections(config, token);
@@ -240,12 +240,12 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                 default: throw new Error(`Unsupported language: ${language}`);
             }
         }
-    
+
         function getPythonDebugConfig(workflowID: string, config: DbosConfig, cloudLensInfo: CloudConnection | undefined): vscode.DebugConfiguration | undefined {
             if (config.language !== "python") {
                 throw new Error(`Expected python language, received ${config.language ?? null}`);
             }
-    
+
             const ext = vscode.extensions.getExtension("ms-python.debugpy");
             if (!ext) {
                 vscode.window.showErrorMessage("Python debugger not found. Please install the Python extension for VSCode.", "Install", "Cancel")
@@ -256,9 +256,9 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     });
                 return undefined;
             }
-    
+
             const timeTravel = cloudLensInfo?.timeTravel ?? false;
-            if (timeTravel)  {
+            if (timeTravel) {
                 vscode.window.showErrorMessage("Python does not support time travel debugging at this time");
                 return undefined;
             }
@@ -280,12 +280,12 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                 }
             };
         }
-    
+
         function getNodeDebugConfig(workflowID: string, config: DbosConfig, cloudLensInfo: CloudConnection | undefined): vscode.DebugConfiguration {
             if ((config.language ?? "node") !== "node") {
                 throw new Error(`Expected node language, received ${config.language ?? null}`);
             }
-    
+
             const timeTravel = cloudLensInfo?.timeTravel ?? false;
             const debugConfig: vscode.DebugConfiguration = {
                 type: 'node',
@@ -297,7 +297,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     ? ["<node_internals>/**/*.js", path.join(path.dirname(config.uri.fsPath), "node_modules", "**", "*.js")]
                     : undefined,
             };
-    
+
             const start = config.runtime?.start ?? [];
             if (start.length === 0) {
                 debugConfig.runtimeExecutable = "npx";
@@ -320,11 +320,11 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             else {
                 throw new Error("multiple runtimeConfig.start command support not implemented");
             }
-    
+
             return debugConfig;
         }
-    
-        function getDebugConfigEnv(cloudLensInfo:  CloudConnection | undefined): Record<string, string> {
+
+        function getDebugConfigEnv(cloudLensInfo: CloudConnection | undefined): Record<string, string> {
             const timeTravel = cloudLensInfo?.timeTravel ?? false;
             if (timeTravel) {
                 return {
@@ -333,11 +333,11 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                     DBOS_DBLOCALSUFFIX: "false",
                 }
             } else if (cloudLensInfo) {
-                return { 
+                return {
                     DBOS_DBHOST: cloudLensInfo.host,
                     DBOS_DBPORT: `${cloudLensInfo.port}`,
                     DBOS_DBUSER: cloudLensInfo.user,
-                    DBOS_DBPASSWORD:  cloudLensInfo.password,
+                    DBOS_DBPASSWORD: cloudLensInfo.password,
                     DBOS_DBLOCALSUFFIX: "false"
                 }
             }
@@ -361,7 +361,6 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             client.release();
         }
 
-        
         async function showWorkflowPicker(client: ClientBase, methodName: string, extensionId: string) {
             const result = await client.query<workflow_status>(
                 "SELECT * FROM dbos.workflow_status WHERE (status = 'SUCCESS' OR status = 'ERROR') AND name = $1 ORDER BY created_at DESC",
@@ -382,7 +381,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                         : `at ${createdAt}`
                 };
             });
-        
+
             const editButton: vscode.QuickInputButton = {
                 iconPath: new vscode.ThemeIcon("edit"),
                 tooltip: "Specify workflow id directly"
@@ -391,7 +390,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
             const consoleButton: vscode.QuickInputButton = {
                 iconPath: new vscode.ThemeIcon("server"),
                 tooltip: "Select workflow via DBOS Cloud Conole"
-              };
+            };
 
             const disposables: { dispose(): any; }[] = [];
             try {
@@ -431,11 +430,11 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
                 }
                 if (result === editButton) {
                     return await vscode.window.showInputBox({ prompt: "Enter the workflow ID" });
-                } 
+                }
                 if (result === consoleButton) {
                     if (!cloudLensInfo) { return undefined; }
                     const path = cloudLensInfo.timeTravel ? "tt-debug" : "debug";
-                    const debugUri =  vscode.Uri.parse(`${vscode.env.uriScheme}://${extensionId}/${path}?app_name=${config.name}`);
+                    const debugUri = vscode.Uri.parse(`${vscode.env.uriScheme}://${extensionId}/${path}?app_name=${config.name}`);
                     const callbackUri = await vscode.env.asExternalUri(debugUri);
 
                     const navigateUri = vscode.Uri.parse(`https://console.dbos.dev/applications/${config.name}/workflows?workflow_name=${methodName}&callback_uri=${encodeURI(callbackUri.toString())}`);
@@ -444,7 +443,7 @@ export class CodeLensProvider implements vscode.CodeLensProvider, vscode.Disposa
 
                     return undefined;
                 }
-                
+
                 throw new Error(`Unexpected button: ${result.tooltip ?? "<unknown>"}`);
             } finally {
                 disposables.forEach(d => d.dispose());

--- a/src/DebugProxyManager.ts
+++ b/src/DebugProxyManager.ts
@@ -10,7 +10,7 @@ import * as semver from 'semver';
 import { Configuration } from './Configuration';
 import { CloudAppItem } from './CloudDataProvider';
 import { CloudCredentialManager } from './CloudCredentialManager';
-import { getDbInstance, getDbProxyRole, isUnauthorized } from './dbosCloudApi';
+import { getDbProxyRole, isUnauthorized } from './dbosCloudApi';
 
 interface DebugProxyOptions {
   host: string;

--- a/src/UriHandler.ts
+++ b/src/UriHandler.ts
@@ -14,29 +14,32 @@ export class UriHandler implements vscode.UriHandler {
         if (!appName || !workflowID) { return; }
 
         const config = await findConfig(appName);
-        if (!config) { return; }
+        if (!config) { 
+            vscode.window.showErrorMessage(`Could not find dbos config file for ${appName} in the current workspace.`);
+            return; 
+        }
 
         const { cloudRelay, timeTravel } = await vscode.commands.executeCommand<CloudConnections>(getCloudConnectionsCommandName, config);
 
         switch (uri.path) {
             case '/debug':
                 if (!cloudRelay) {
-                    await vscode.window.showErrorMessage(`No cloud relay found for ${appName}`);
+                    vscode.window.showErrorMessage(`Cloud replay connection information for ${appName} not found`);
                     return;
                 }
-                await vscode.window.showInformationMessage(`Starting DBOS Replay Debugger for ${appName} with workflow ID ${workflowID}`);
+                vscode.window.showInformationMessage(`Starting DBOS Replay Debugger for ${appName} with workflow ID ${workflowID}`);
                 await vscode.commands.executeCommand(launchDebuggerCommandName, workflowID, config, cloudRelay);
                 break;
             case '/tt-debug':
                 if (!timeTravel) {
-                    await vscode.window.showErrorMessage(`No cloud relay found for ${appName}`);
+                    vscode.window.showErrorMessage(`Time travel connection information for ${appName} not found`);
                     return;
                 }
-                await vscode.window.showInformationMessage(`Starting DBOS TimeTravel Debugger for ${appName} with workflow ID ${workflowID}`);
+                vscode.window.showInformationMessage(`Starting DBOS TimeTravel Debugger for ${appName} with workflow ID ${workflowID}`);
                 await vscode.commands.executeCommand(launchDebuggerCommandName, workflowID, config, timeTravel);
                 break;
             default:
-                vscode.window.showErrorMessage(`Unsupported uri: ${uri.path}}`);
+                vscode.window.showErrorMessage(`Unsupported DBOS Debugger uri path: ${uri.path}}`);
         }
 
         async function findConfig(appName: string) {

--- a/src/UriHandler.ts
+++ b/src/UriHandler.ts
@@ -1,5 +1,8 @@
 import * as vscode from 'vscode';
-import { logger } from './extension';
+import { getCloudConnectionsCommandName, launchDebuggerCommandName, logger } from './extension';
+import { DbosConfig, loadConfigFile } from './dbosConfig';
+import type { CloudConnections } from './CodeLensProvider';
+import { time } from 'console';
 
 export class UriHandler implements vscode.UriHandler {
     async handleUri(uri: vscode.Uri): Promise<void> {
@@ -8,15 +11,44 @@ export class UriHandler implements vscode.UriHandler {
         const appName = searchParams.get('app_name');
         const workflowID = searchParams.get('workflow_id');
 
+        if (!appName || !workflowID) { return; }
+
+        const config = await findConfig(appName);
+        if (!config) { return; }
+
+        const { cloudRelay, timeTravel } = await vscode.commands.executeCommand<CloudConnections>(getCloudConnectionsCommandName, config);
+
         switch (uri.path) {
             case '/debug':
-                vscode.window.showInformationMessage(`Starting DBOS Replay Debugger for ${appName} with workflow ID ${workflowID}`);
+                if (!cloudRelay) {
+                    await vscode.window.showErrorMessage(`No cloud relay found for ${appName}`);
+                    return;
+                }
+                await vscode.window.showInformationMessage(`Starting DBOS Replay Debugger for ${appName} with workflow ID ${workflowID}`);
+                await vscode.commands.executeCommand(launchDebuggerCommandName, workflowID, config, cloudRelay);
                 break;
             case '/tt-debug':
-                vscode.window.showInformationMessage(`Starting DBOS TimeTravel Debugger for ${appName} with workflow ID ${workflowID}`);
+                if (!timeTravel) {
+                    await vscode.window.showErrorMessage(`No cloud relay found for ${appName}`);
+                    return;
+                }
+                await vscode.window.showInformationMessage(`Starting DBOS TimeTravel Debugger for ${appName} with workflow ID ${workflowID}`);
+                await vscode.commands.executeCommand(launchDebuggerCommandName, workflowID, config, timeTravel);
                 break;
             default:
                 vscode.window.showErrorMessage(`Unsupported uri: ${uri.path}}`);
         }
+
+        async function findConfig(appName: string) {
+            const configFiles = await vscode.workspace.findFiles('**/dbos-config.yaml');
+            for (const configFile of configFiles) {
+                const config = await loadConfigFile(configFile);
+                if (config && config.name === appName) {
+                    return config;
+                }
+            }
+            return undefined;
+        }
+    
     }
 }

--- a/src/UriHandler.ts
+++ b/src/UriHandler.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import { getCloudConnectionsCommandName, launchDebuggerCommandName, logger } from './extension';
-import { DbosConfig, loadConfigFile } from './dbosConfig';
+import { loadConfigFile } from './dbosConfig';
 import type { CloudConnections } from './CodeLensProvider';
-import { time } from 'console';
 
 export class UriHandler implements vscode.UriHandler {
     async handleUri(uri: vscode.Uri): Promise<void> {

--- a/src/UriHandler.ts
+++ b/src/UriHandler.ts
@@ -1,0 +1,22 @@
+import * as vscode from 'vscode';
+import { logger } from './extension';
+
+export class UriHandler implements vscode.UriHandler {
+    async handleUri(uri: vscode.Uri): Promise<void> {
+        logger.info(`UriHandler.handleUri`, { uri: uri.toString() });
+        const searchParams = new URLSearchParams(uri.query);
+        const appName = searchParams.get('app_name');
+        const workflowID = searchParams.get('workflow_id');
+
+        switch (uri.path) {
+            case '/debug':
+                vscode.window.showInformationMessage(`Starting DBOS Replay Debugger for ${appName} with workflow ID ${workflowID}`);
+                break;
+            case '/tt-debug':
+                vscode.window.showInformationMessage(`Starting DBOS TimeTravel Debugger for ${appName} with workflow ID ${workflowID}`);
+                break;
+            default:
+                vscode.window.showErrorMessage(`Unsupported uri: ${uri.path}}`);
+        }
+    }
+}

--- a/src/dbosTables.ts
+++ b/src/dbosTables.ts
@@ -1,0 +1,20 @@
+export interface workflow_status {
+    workflow_uuid: string;
+    status: string | null;
+    name: string | null;
+    authenticated_user: string | null;
+    assumed_role: string | null;
+    authenticated_roles: string | null;
+    request: string | null;
+    output: string | null;
+    error: string | null;
+    executor_id: string | null;
+    created_at: string; // actually a bigint
+    updated_at: string; // actually a bigint
+    application_version: string | null;
+    application_id: string | null;
+    class_name: string | null;
+    config_name: string | null;
+    recovery_attempts: string | null; // actually a nullable bigint
+    queue_name: string | null;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { CloudDataProvider } from './CloudDataProvider';
 import { CloudCredentialManager } from './CloudCredentialManager';
 import { S3Storage } from './BlobStorage';
 import { DebugProxyManager } from './DebugProxyManager';
+import { UriHandler } from './UriHandler';
 
 export let logger: Logger;
 
@@ -44,6 +45,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerCodeLensProvider(
       [{ language: 'python' }, { language: 'typescript' }],
       codeLensProvider),
+    vscode.window.registerUriHandler(new UriHandler()),
 
     vscode.commands.registerCommand(
       cloudLoginCommandName,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,8 @@ export const startDebuggingCodeLensCommandName = "dbos-ttdbg.start-debugging-cod
 const browseCloudAppCommandName = "dbos-ttdbg.browse-cloud-app";
 const updateDebugProxyCommandName = "dbos-ttdbg.update-debug-proxy";
 const launchDebugProxyCommandName = "dbos-ttdbg.launch-debug-proxy";
+export const getCloudConnectionsCommandName = "dbos-ttdbg.get-cloud-connections";
+export const launchDebuggerCommandName = "dbos-ttdbg.launch-debugger";
 
 export async function activate(context: vscode.ExtensionContext) {
 
@@ -56,6 +58,12 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       startDebuggingCodeLensCommandName,
       codeLensProvider.getCodeLensDebugCommand()),
+    vscode.commands.registerCommand(
+      launchDebuggerCommandName,
+      codeLensProvider.getLaunchDebuggerCommand()),
+    vscode.commands.registerCommand(
+      getCloudConnectionsCommandName,
+      codeLensProvider.getGetCloudConnectionsCommand()),
     vscode.commands.registerCommand(
       browseCloudAppCommandName,
       CloudDataProvider.browseCloudApp),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export async function activate(context: vscode.ExtensionContext) {
     credManager,
     context.globalStorageUri);
   const cloudDataProvider = new CloudDataProvider(credManager);
-  const codeLensProvider = new CodeLensProvider(credManager, debugProxyManager);
+  const codeLensProvider = new CodeLensProvider(context.extension.id, credManager, debugProxyManager);
   const blobStorage = new S3Storage();
 
   context.subscriptions.push(


### PR DESCRIPTION
* Adds (back) URI handler for launching debugger (replay or time travel) from external source 
* Added console quick pick button to cloud replay/time travel debug WF picker to navigate to DBOS Cloud Console for advanced picking scenarios
* Assorted refactoring to separate WF ID picking from debug launching to enable URI handler