### PR TITLE
add null check operator to enterDecorated

### DIFF
--- a/src/parsers/pyParser.ts
+++ b/src/parsers/pyParser.ts
@@ -48,7 +48,7 @@ class DbosPythonListener extends Python3ParserListener {
     };
 
     enterDecorated = (ctx: DecoratedContext) => {
-        const funcDef = ctx.funcdef() ?? ctx.async_funcdef().funcdef();
+        const funcDef = ctx.funcdef() ?? ctx.async_funcdef()?.funcdef();
         if (!funcDef) { return; }
         const start = ctx.start.start;
         const stop = ctx.stop?.stop ?? ctx.start.stop;


### PR DESCRIPTION
fixes #52

The parser generated by ANTLR does not correctly mark context retrieval return values as nullable. A function like `ctx.async_funcdef()` (used in `DbosPythonListener.enterDecorated`) is typed as returning an `Async_funcdefContext` but really returns `Async_funcdefContext | null`. So TS compiler type checking failed to identify the need for a null check operator.